### PR TITLE
Remap config option/labels to prevent magento commerce modules from creating exception

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -146,7 +146,7 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
             $labels = []; //reset labels so we can add human-friendly labels
 
             $optionsByValue = [];
-            foreach($field->getOptions() as $option) {
+            foreach($field->getOptions() as $id => $option) {
                 // Magento Enterprise modules can have different configuration value/label structure
                 if ($option instanceof \Magento\Framework\Phrase) {
                     $option = [

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -147,6 +147,13 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
             $optionsByValue = [];
             foreach($field->getOptions() as $option) {
+                // Magento Enterprise modules can have different configuration value/label structure
+                if ($option instanceof \Magento\Framework\Phrase) {
+                    $option = [
+                        'value' => $id,
+                        'label' => $option
+                    ];
+                }
                 if (isset($option['value'])) {
                     $optionsByValue[$option['value']] = $option;
                 }


### PR DESCRIPTION
Configscopehints expects option arrays to be mapped like 
```
[
    ['value' => int, 'label' => \Magento\Framework\Phrase],
    ...
]
```
Magento community modules are mapped like this

Magento commerce modules like CatalogPermissions instead maps it like
```
[
    int => \Magento\Framework\Phrase,
    ...
]
```

Related Jira issue code: MSBS-106