### PR TITLE
[BUGFIX] Fixed rendering values for dynamic config rows.

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -159,9 +159,13 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
                         'label' => $option
                     ];
                 }
-                if (isset($option['value'])) {
-                    $optionsByValue[$option['value']] = $option;
+                if (!isset($option['value'])){
+                    continue;
                 }
+                if (is_array($option['value'])) {
+                    $option['value'] = json_encode($option['value']);
+                }
+                $optionsByValue[$option['value']] = $option;
             }
 
             if (is_array($value)) {


### PR DESCRIPTION
**PR description**
In this PR added more defensive code, which will render saved value as encoded JSON .. 

**Tech. description**
In case configuration is saved as "dynamic config rows" type, `$option['value']` will be type of array, which will throw an error on line `163`.